### PR TITLE
Fix handling of articles without authors

### DIFF
--- a/CoinsPlugin.inc.php
+++ b/CoinsPlugin.inc.php
@@ -71,9 +71,6 @@ class CoinsPlugin extends GenericPlugin {
 			$journal = $templateMgr->get_template_vars('currentJournal');
 			$issue = $templateMgr->get_template_vars('issue');
 
-			$authors = $article->getAuthors();
-			$firstAuthor =& $authors[0];
-
 			$vars = array(
 				array('ctx_ver', 'Z39.88-2004'),
 				array('rft_id', $request->url(null, 'article', 'view', $article->getId())),
@@ -86,10 +83,16 @@ class CoinsPlugin extends GenericPlugin {
 				array('rft.stitle', $journal->getLocalizedSetting('abbreviation')),
 				array('rft.volume', $issue->getVolume()),
 				array('rft.issue', $issue->getNumber()),
-				array('rft.aulast', $firstAuthor->getLastName()),
-				array('rft.aufirst', $firstAuthor->getFirstName()),
-				array('rft.auinit', $firstAuthor->getMiddleName())
 			);
+
+			$authors = $article->getAuthors();
+			if ($firstAuthor = array_shift($authors)) {
+				$vars = array_merge($vars, array(
+					array('rft.aulast', $firstAuthor->getLastName()),
+					array('rft.aufirst', $firstAuthor->getFirstName()),
+					array('rft.auinit', $firstAuthor->getMiddleName()),
+				));
+			}
 
 			$datePublished = $article->getDatePublished();
 			if (!$datePublished) {


### PR DESCRIPTION
This is a re-diff of https://github.com/pkp/ojs/commit/1a52f14709c5799d64096e220edc15edf4e4eeb0 which was in the OJS copy of the coins plugin but seems to be missing in the coins submodule.

Without this patch I sometimes see this error in the log file:
```
 PHP Fatal error:  Call to a member function getLastName() on null in /srv/ojs/ojs3-stage/webroot/plugins/generic/coins/CoinsPlugin.inc.php on line 89
```

Forum reference for the original patch:
https://forum.pkp.sfu.ca/t/ojs-3-0-2-right-panel-disappeared-after-adding-announcement/29308/4
